### PR TITLE
Refactor test emails and create script to add projects to a test user

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "initDB": "npm run build && node dist/db/init_database.js",
     "importTestData": "npm run build && node dist/db/import_test_data.js",
     "productionStart": "apidoc -i src/ -o docs/ && npm start",
-    "initTestDB": "npm run createDB && npm run initDB && npm run importTestData"
+    "initTestDB": "npm run createDB && npm run initDB && npm run importTestData",
+    "addProjectsToTestUser": "npm run build && node dist/db/add_projects_to_test_user.js"
   },
   "pre-commit": [
     "lint"

--- a/src/db/add_projects_to_test_user.js
+++ b/src/db/add_projects_to_test_user.js
@@ -1,0 +1,71 @@
+import sequelize from './sequelize';
+
+
+// This script takes a username as an argument and adds various test data
+// to his or her account. It makes that user an owner for project 'b1', a
+// contributor for project 'b2', and an invitee for project 'b3'.
+// It should only be run after running the import_test_data.js script.
+
+function usageAndExit() {
+  console.error("\nUSAGE: npm run addProjectsToTestUser <username>\n"); // eslint-disable-line
+  process.exit(1);
+}
+
+export async function populateProjects(username) {
+  const project1 = await sequelize.Project.findOne({ where: { id: 'b1' } });
+  const project2 = await sequelize.Project.findOne({ where: { id: 'b2' } });
+  const user = await sequelize.User.findOne({ where: { username } });
+  await project1.addOwners(user);
+  await project2.addContributors(user);
+}
+
+export async function populateInvites(username) {
+  const user = await sequelize.User.findOne({ where: { username } });
+  const project3 = await sequelize.Project.findOne({ where: { id: 'b3' } });
+  await sequelize.Invite.create({
+    id: 'd123',
+    status: sequelize.InviteStatus.OPEN,
+    userInvitedId: user.id,
+    projectInvitedToId: project3.id,
+    projectName: project3.projectName,
+    daysFromCreationUntilExpiration: 30
+  });
+}
+
+export async function populateAllTestData(username) {
+  await populateProjects(username);
+  await populateInvites(username);
+}
+
+
+/**
+ * ---------------------------- MAIN ----------------------------
+ * The main function only gets run if this file is run as a script
+ */
+function main(username) {
+  // First, we need to initialize the data model
+  sequelize.initSequelize();
+
+  // Then, continue populating the test data
+  populateAllTestData(username).then(() => {
+    process.exit(0);
+  }).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+
+// ---------------- If this is running as a script, call main ----------------
+if (!module.parent) {
+  process.argv.forEach((str) => {
+    console.log(str);
+  });
+  if (process.argv.length > 1 && process.argv[2].length > 0) {
+    const username = process.argv[2];
+    console.log(`\nAdding '${username}' as owner of project b1, contributor to b2, and invited to b3.\n`);
+    main(username);
+  } else {
+    usageAndExit();
+  }
+}

--- a/src/db/import_test_data.js
+++ b/src/db/import_test_data.js
@@ -9,35 +9,35 @@ export async function populateUsers() {
     {
       id: 'a1',
       username: 'BobSagat',
-      email: 'Bob@AFV.com',
+      email: 'hammer.io.team@gmail.com',
       firstName: 'Bob',
       lastName: 'Sagat'
     },
     {
       id: 'a2',
       username: 'globalwarmingguy56',
-      email: 'Al@saveourplanet.com',
+      email: 'hammer.io.team@gmail.com',
       firstName: 'Al',
       lastName: 'Gore'
     },
     {
       id: 'a3',
       username: 'jreach',
-      email: 'jreach@gmail.com',
+      email: 'hammer.io.team@gmail.com',
       firstName: 'Jack',
       lastName: 'Reacher'
     },
     {
       id: 'a4',
       username: 'johnnyb',
-      email: 'jbravo@cartoonnetwork.com',
+      email: 'hammer.io.team@gmail.com',
       firstName: 'Johnny',
       lastName: 'Bravo'
     },
     {
       id: 'a5',
       username: 'buddy',
-      email: 'buddy@carnegiehall.org',
+      email: 'hammer.io.team@gmail.com',
       firstName: 'Buddy',
       lastName: 'Rich'
     }

--- a/test/routes-tests/users.routes.test.js
+++ b/test/routes-tests/users.routes.test.js
@@ -89,7 +89,7 @@ describe('Testing User Routes', () => {
           expect(user.id).to.equal('a3');
           expect(user.firstName).to.equal('Jack');
           expect(user.lastName).to.equal('Dorsey');
-          expect(user.email).to.equal('jreach@gmail.com');
+          expect(user.email).to.equal('hammer.io.team@gmail.com');
           done();
         });
     });

--- a/test/service-tests/projects.service.test.js
+++ b/test/service-tests/projects.service.test.js
@@ -70,7 +70,7 @@ describe('Testing Project Service', async () => {
 
       expect(owners[0].id).to.equal('a4');
       expect(owners[0].username).to.equal('johnnyb');
-      expect(owners[0].email).to.equal('jbravo@cartoonnetwork.com');
+      expect(owners[0].email).to.equal('hammer.io.team@gmail.com');
       expect(owners[0].firstName).to.equal('Johnny');
       expect(owners[0].lastName).to.equal('Bravo');
     });

--- a/test/service-tests/users.service.test.js
+++ b/test/service-tests/users.service.test.js
@@ -17,7 +17,7 @@ describe('Testing User Service', () => {
       const userServiceFoundUser = await userService.getUserByIdOrUsername('BobSagat');
       expect(userServiceFoundUser.id).to.equal('a1');
       expect(userServiceFoundUser.username).to.equal('BobSagat');
-      expect(userServiceFoundUser.email).to.equal('Bob@AFV.com');
+      expect(userServiceFoundUser.email).to.equal('hammer.io.team@gmail.com');
       expect(userServiceFoundUser.firstName).to.equal('Bob');
       expect(userServiceFoundUser.lastName).to.equal('Sagat');
     });
@@ -26,7 +26,7 @@ describe('Testing User Service', () => {
       const userServiceFoundUser = await userService.getUserByIdOrUsername('a1');
       expect(userServiceFoundUser.id).to.equal('a1');
       expect(userServiceFoundUser.username).to.equal('BobSagat');
-      expect(userServiceFoundUser.email).to.equal('Bob@AFV.com');
+      expect(userServiceFoundUser.email).to.equal('hammer.io.team@gmail.com');
       expect(userServiceFoundUser.firstName).to.equal('Bob');
       expect(userServiceFoundUser.lastName).to.equal('Sagat');
     });
@@ -60,10 +60,10 @@ describe('Testing User Service', () => {
 
   describe('get user by email', async () => {
     it('should find a user by email', async () => {
-      const userServiceFoundUser = await userService.getUserByEmail('Bob@AFV.com');
+      const userServiceFoundUser = await userService.getUserByEmail('hammer.io.team@gmail.com');
       expect(userServiceFoundUser.id).to.equal('a1');
       expect(userServiceFoundUser.username).to.equal('BobSagat');
-      expect(userServiceFoundUser.email).to.equal('Bob@AFV.com');
+      expect(userServiceFoundUser.email).to.equal('hammer.io.team@gmail.com');
       expect(userServiceFoundUser.firstName).to.equal('Bob');
       expect(userServiceFoundUser.lastName).to.equal('Sagat');
     });
@@ -344,7 +344,7 @@ describe('Testing User Service', () => {
     it('should have an error for duplicate email', async () => {
       const newUser = {
         username: 'newusername',
-        email: 'Bob@AFV.com',
+        email: 'hammer.io.team@gmail.com',
         firstName: 'Bob',
         lastName: 'Sagat'
       };
@@ -469,7 +469,7 @@ describe('Testing User Service', () => {
     it('should have an error for duplicate email', async () => {
       const newUser = {
         username: 'newusername',
-        email: 'Bob@AFV.com',
+        email: 'hammer.io.team@gmail.com',
         firstName: 'Bob',
         lastName: 'Sagat'
       };
@@ -511,7 +511,7 @@ describe('Testing User Service', () => {
       // check the deleted user information
       expect(deletedUser.id).to.equal('a1');
       expect(deletedUser.username).to.equal('BobSagat');
-      expect(deletedUser.email).to.equal('Bob@AFV.com');
+      expect(deletedUser.email).to.equal('hammer.io.team@gmail.com');
       expect(deletedUser.firstName).to.equal('Bob');
       expect(deletedUser.lastName).to.equal('Sagat');
     });
@@ -635,7 +635,7 @@ describe('Testing User Service', () => {
     it('should validate for duplicate usernames and emails', async () => {
       const newUser = {
         username: 'BobSagat',
-        email: 'Bob@AFV.com',
+        email: 'hammer.io.team@gmail.com',
         firstName: 'Bob',
         lastName: 'Sagat'
       };
@@ -657,7 +657,7 @@ describe('Testing User Service', () => {
       const user = await userService.getCredentialsByUsername(username, password);
       expect(user.username).to.equal(username);
       expect(user.password).to.be.an('undefined');
-      expect(user.email).to.equal('jreach@gmail.com');
+      expect(user.email).to.equal('hammer.io.team@gmail.com');
       expect(user.firstName).to.equal('Jack');
       expect(user.lastName).to.equal('Reacher');
     });


### PR DESCRIPTION
For manual testing during development, the test users added via scripts shouldn't have fake emails because now that we're integrated with firebase, there's the potential for REAL firebase auth being created for email accounts that we don't own. The test users' emails were refactored to our hammer team email. In addition, a script was created to facilitate adding projects to a dynamically-created user account. This lets you register a new user during development and quickly give them some of the test projects so you can see more functionality in the app. Again, this need arose because none of the default test users are actually connected to firebase. Since we have to register a new user through the application, we'd like that new user to be connected to some of the projects for testing.

Clear as mud?