### PR TITLE
fixes issue issues/builds/commits throwing 500 error

### DIFF
--- a/src/controllers/projects.controller.js
+++ b/src/controllers/projects.controller.js
@@ -69,7 +69,7 @@ async function setSequelizeCredentials(configs, user) {
 async function setGithubRepositoryName(configs) {
   const projectName = configs.projectConfigurations.projectName;
   const githubUsername = configs.credentials.github.username;
-  return `/${githubUsername}/${projectName}`;
+  return `${githubUsername}/${projectName}`;
 }
 
 /**
@@ -80,7 +80,7 @@ async function setGithubRepositoryName(configs) {
 async function setTravisRepositoryName(configs) {
   const projectName = configs.projectConfigurations.projectName;
   const githubUsername = configs.credentials.github.username;
-  return `/${githubUsername}/${projectName}`;
+  return `${githubUsername}/${projectName}`;
 }
 
 /**


### PR DESCRIPTION
closes #73 

* issue was that the github repo and travis repo names were being stored with an extra slash in the database.